### PR TITLE
Add SideNotes-style Obsidian plugin scaffold

### DIFF
--- a/obsidian-sidenotes-plugin/README.md
+++ b/obsidian-sidenotes-plugin/README.md
@@ -1,0 +1,16 @@
+# SideNotes Panel (Obsidian Plugin)
+
+This plugin mirrors the "SideNotes" app behavior inside Obsidian by keeping a dedicated note in a slide-out panel on the right edge of your screen.
+
+## Features
+- Slide-out panel that appears when your cursor reaches the right edge and hides when you move away.
+- Fully editable Obsidian note inside the panel.
+- Adjustable width, activation distance, and peek width.
+
+## Setup
+1. Build the plugin as usual for Obsidian (copy `manifest.json`, `main.js`, and `styles.css` into your vault's plugins folder).
+2. Enable **SideNotes Panel** in Obsidian settings.
+3. Use the settings tab to choose which note to show and tweak the panel behavior.
+
+## Suggested note
+The default note is `SideNotes.md`. You can change the path to any existing note.

--- a/obsidian-sidenotes-plugin/README.md
+++ b/obsidian-sidenotes-plugin/README.md
@@ -8,7 +8,7 @@ This plugin mirrors the "SideNotes" app behavior inside Obsidian by keeping a de
 - Adjustable width, activation distance, and peek width.
 
 ## Setup
-1. Build the plugin as usual for Obsidian (copy `manifest.json`, `main.js`, and `styles.css` into your vault's plugins folder).
+1. Copy `manifest.json`, `main.js`, and `styles.css` into your vault's `.obsidian/plugins/obsidian-sidenotes/` folder.
 2. Enable **SideNotes Panel** in Obsidian settings.
 3. Use the settings tab to choose which note to show and tweak the panel behavior.
 

--- a/obsidian-sidenotes-plugin/main.js
+++ b/obsidian-sidenotes-plugin/main.js
@@ -1,0 +1,173 @@
+const obsidian = require("obsidian");
+
+const DEFAULT_SETTINGS = {
+  notePath: "SideNotes.md",
+  panelWidth: 360,
+  edgeThreshold: 24,
+  peekWidth: 12,
+};
+
+class SideNotesSettingTab extends obsidian.PluginSettingTab {
+  constructor(app, plugin) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display() {
+    const { containerEl } = this;
+
+    containerEl.empty();
+    containerEl.createEl("h2", { text: "SideNotes Panel" });
+
+    new obsidian.Setting(containerEl)
+      .setName("Note path")
+      .setDesc("Path to the note that should appear in the side panel.")
+      .addText((text) =>
+        text
+          .setPlaceholder("SideNotes.md")
+          .setValue(this.plugin.settings.notePath)
+          .onChange(async (value) => {
+            this.plugin.settings.notePath = value;
+            await this.plugin.saveSettings();
+            await this.plugin.ensureLeaf();
+          })
+      );
+
+    new obsidian.Setting(containerEl)
+      .setName("Panel width")
+      .setDesc("Width of the slide-out panel in pixels.")
+      .addSlider((slider) =>
+        slider
+          .setLimits(240, 640, 20)
+          .setValue(this.plugin.settings.panelWidth)
+          .setDynamicTooltip()
+          .onChange(async (value) => {
+            this.plugin.settings.panelWidth = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new obsidian.Setting(containerEl)
+      .setName("Edge activation distance")
+      .setDesc("How close the cursor needs to be to the right edge to open the panel.")
+      .addSlider((slider) =>
+        slider
+          .setLimits(8, 96, 4)
+          .setValue(this.plugin.settings.edgeThreshold)
+          .setDynamicTooltip()
+          .onChange(async (value) => {
+            this.plugin.settings.edgeThreshold = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new obsidian.Setting(containerEl)
+      .setName("Peek width")
+      .setDesc("How much of the panel remains visible when hidden.")
+      .addSlider((slider) =>
+        slider
+          .setLimits(0, 40, 2)
+          .setValue(this.plugin.settings.peekWidth)
+          .setDynamicTooltip()
+          .onChange(async (value) => {
+            this.plugin.settings.peekWidth = value;
+            await this.plugin.saveSettings();
+          })
+      );
+  }
+}
+
+module.exports = class SideNotesPlugin extends obsidian.Plugin {
+  constructor(app, manifest) {
+    super(app, manifest);
+    this.settings = DEFAULT_SETTINGS;
+    this.leaf = null;
+    this.isPointerInPanel = false;
+    this.isFocused = false;
+    this.isNearEdge = false;
+  }
+
+  async onload() {
+    await this.loadSettings();
+    this.applyCssVariables();
+    this.addSettingTab(new SideNotesSettingTab(this.app, this));
+
+    await this.ensureLeaf();
+    this.registerDomEvent(window, "mousemove", (event) => {
+      this.isNearEdge = window.innerWidth - event.clientX <= this.settings.edgeThreshold;
+      this.updateOpenState();
+    });
+  }
+
+  onunload() {
+    if (this.leaf) {
+      this.leaf.detach();
+      this.leaf = null;
+    }
+    document.body.classList.remove("sidenotes-open");
+  }
+
+  async ensureLeaf() {
+    if (this.leaf) {
+      return;
+    }
+
+    const file = await this.ensureNoteFile();
+    const leaf = this.app.workspace.getLeaf("window");
+    await leaf.openFile(file, { active: false });
+
+    leaf.containerEl.addClass("sidenotes-panel");
+    this.leaf = leaf;
+
+    this.registerDomEvent(leaf.containerEl, "mouseenter", () => {
+      this.isPointerInPanel = true;
+      this.updateOpenState();
+    });
+
+    this.registerDomEvent(leaf.containerEl, "mouseleave", () => {
+      this.isPointerInPanel = false;
+      this.updateOpenState();
+    });
+
+    this.registerDomEvent(leaf.containerEl, "focusin", () => {
+      this.isFocused = true;
+      this.updateOpenState();
+    });
+
+    this.registerDomEvent(leaf.containerEl, "focusout", () => {
+      this.isFocused = false;
+      this.updateOpenState();
+    });
+  }
+
+  async ensureNoteFile() {
+    const trimmedPath = this.settings.notePath.trim();
+    const path = trimmedPath.length > 0 ? trimmedPath : DEFAULT_SETTINGS.notePath;
+    const existing = this.app.vault.getAbstractFileByPath(path);
+
+    if (existing instanceof obsidian.TFile) {
+      return existing;
+    }
+
+    return this.app.vault.create(path, "# SideNotes\n\nStart writing your quick note here.\n");
+  }
+
+  updateOpenState() {
+    const shouldOpen = this.isNearEdge || this.isPointerInPanel || this.isFocused;
+    document.body.classList.toggle("sidenotes-open", shouldOpen);
+  }
+
+  applyCssVariables() {
+    document.body.style.setProperty("--sidenotes-width", `${this.settings.panelWidth}px`);
+    document.body.style.setProperty("--sidenotes-peek", `${this.settings.peekWidth}px`);
+  }
+
+  async loadSettings() {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
+
+  async saveSettings() {
+    await this.saveData(this.settings);
+    this.applyCssVariables();
+  }
+};

--- a/obsidian-sidenotes-plugin/main.ts
+++ b/obsidian-sidenotes-plugin/main.ts
@@ -1,0 +1,186 @@
+import {
+  App,
+  Plugin,
+  PluginSettingTab,
+  Setting,
+  TFile,
+  WorkspaceLeaf,
+} from "obsidian";
+
+interface SideNotesSettings {
+  notePath: string;
+  panelWidth: number;
+  edgeThreshold: number;
+  peekWidth: number;
+}
+
+const DEFAULT_SETTINGS: SideNotesSettings = {
+  notePath: "SideNotes.md",
+  panelWidth: 360,
+  edgeThreshold: 24,
+  peekWidth: 12,
+};
+
+export default class SideNotesPlugin extends Plugin {
+  settings: SideNotesSettings = DEFAULT_SETTINGS;
+  leaf: WorkspaceLeaf | null = null;
+  private isPointerInPanel = false;
+  private isFocused = false;
+  private isNearEdge = false;
+
+  async onload() {
+    await this.loadSettings();
+    this.applyCssVariables();
+    this.addSettingTab(new SideNotesSettingTab(this.app, this));
+
+    await this.ensureLeaf();
+    this.registerDomEvent(window, "mousemove", (event: MouseEvent) => {
+      this.isNearEdge = window.innerWidth - event.clientX <= this.settings.edgeThreshold;
+      this.updateOpenState();
+    });
+  }
+
+  onunload() {
+    if (this.leaf) {
+      this.leaf.detach();
+      this.leaf = null;
+    }
+    document.body.classList.remove("sidenotes-open");
+  }
+
+  async ensureLeaf() {
+    if (this.leaf) {
+      return;
+    }
+
+    const file = await this.ensureNoteFile();
+    const leaf = this.app.workspace.getLeaf("window");
+    await leaf.openFile(file, { active: false });
+
+    leaf.containerEl.addClass("sidenotes-panel");
+    this.leaf = leaf;
+
+    this.registerDomEvent(leaf.containerEl, "mouseenter", () => {
+      this.isPointerInPanel = true;
+      this.updateOpenState();
+    });
+
+    this.registerDomEvent(leaf.containerEl, "mouseleave", () => {
+      this.isPointerInPanel = false;
+      this.updateOpenState();
+    });
+
+    this.registerDomEvent(leaf.containerEl, "focusin", () => {
+      this.isFocused = true;
+      this.updateOpenState();
+    });
+
+    this.registerDomEvent(leaf.containerEl, "focusout", () => {
+      this.isFocused = false;
+      this.updateOpenState();
+    });
+  }
+
+  async ensureNoteFile(): Promise<TFile> {
+    const trimmedPath = this.settings.notePath.trim();
+    const path = trimmedPath.length > 0 ? trimmedPath : DEFAULT_SETTINGS.notePath;
+    const existing = this.app.vault.getAbstractFileByPath(path);
+
+    if (existing instanceof TFile) {
+      return existing;
+    }
+
+    return this.app.vault.create(path, "# SideNotes\n\nStart writing your quick note here.\n");
+  }
+
+  updateOpenState() {
+    const shouldOpen = this.isNearEdge || this.isPointerInPanel || this.isFocused;
+    document.body.classList.toggle("sidenotes-open", shouldOpen);
+  }
+
+  applyCssVariables() {
+    document.body.style.setProperty("--sidenotes-width", `${this.settings.panelWidth}px`);
+    document.body.style.setProperty("--sidenotes-peek", `${this.settings.peekWidth}px`);
+  }
+
+  async loadSettings() {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
+
+  async saveSettings() {
+    await this.saveData(this.settings);
+    this.applyCssVariables();
+  }
+}
+
+class SideNotesSettingTab extends PluginSettingTab {
+  plugin: SideNotesPlugin;
+
+  constructor(app: App, plugin: SideNotesPlugin) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    const { containerEl } = this;
+
+    containerEl.empty();
+    containerEl.createEl("h2", { text: "SideNotes Panel" });
+
+    new Setting(containerEl)
+      .setName("Note path")
+      .setDesc("Path to the note that should appear in the side panel.")
+      .addText((text) =>
+        text
+          .setPlaceholder("SideNotes.md")
+          .setValue(this.plugin.settings.notePath)
+          .onChange(async (value) => {
+            this.plugin.settings.notePath = value;
+            await this.plugin.saveSettings();
+            await this.plugin.ensureLeaf();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName("Panel width")
+      .setDesc("Width of the slide-out panel in pixels.")
+      .addSlider((slider) =>
+        slider
+          .setLimits(240, 640, 20)
+          .setValue(this.plugin.settings.panelWidth)
+          .setDynamicTooltip()
+          .onChange(async (value) => {
+            this.plugin.settings.panelWidth = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName("Edge activation distance")
+      .setDesc("How close the cursor needs to be to the right edge to open the panel.")
+      .addSlider((slider) =>
+        slider
+          .setLimits(8, 96, 4)
+          .setValue(this.plugin.settings.edgeThreshold)
+          .setDynamicTooltip()
+          .onChange(async (value) => {
+            this.plugin.settings.edgeThreshold = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName("Peek width")
+      .setDesc("How much of the panel remains visible when hidden.")
+      .addSlider((slider) =>
+        slider
+          .setLimits(0, 40, 2)
+          .setValue(this.plugin.settings.peekWidth)
+          .setDynamicTooltip()
+          .onChange(async (value) => {
+            this.plugin.settings.peekWidth = value;
+            await this.plugin.saveSettings();
+          })
+      );
+  }
+}

--- a/obsidian-sidenotes-plugin/manifest.json
+++ b/obsidian-sidenotes-plugin/manifest.json
@@ -1,0 +1,10 @@
+{
+  "id": "obsidian-sidenotes",
+  "name": "SideNotes Panel",
+  "version": "0.1.0",
+  "minAppVersion": "1.4.0",
+  "description": "Slides a dedicated note in from the edge of the screen and hides it when you move away.",
+  "author": "OpenAI",
+  "authorUrl": "https://openai.com",
+  "isDesktopOnly": true
+}

--- a/obsidian-sidenotes-plugin/styles.css
+++ b/obsidian-sidenotes-plugin/styles.css
@@ -1,0 +1,23 @@
+.sidenotes-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: var(--sidenotes-width, 360px);
+  transform: translateX(calc(100% - var(--sidenotes-peek, 12px)));
+  transition: transform 150ms ease;
+  z-index: 100;
+  box-shadow: -8px 0 16px rgba(0, 0, 0, 0.15);
+}
+
+body.sidenotes-open .sidenotes-panel {
+  transform: translateX(0);
+}
+
+.sidenotes-panel .view-header {
+  border-left: 1px solid var(--background-modifier-border);
+}
+
+.sidenotes-panel .view-content {
+  background-color: var(--background-primary);
+}


### PR DESCRIPTION
### Motivation
- Provide an Obsidian plugin that replicates the SideNotes app behavior by sliding a dedicated note in from the right edge of the screen and hiding it when the pointer moves away.
- Allow quick, always-editable access to a single note while keeping the feature configurable and desktop-only for Obsidian users.

### Description
- Add `manifest.json` to declare the plugin (`obsidian-sidenotes`) and mark it as desktop-only with basic metadata.
- Implement plugin logic in `main.ts` to create/open the configured note, attach a workspace leaf, detect `mousemove` proximity to the right edge, and register `mouseenter`/`mouseleave`/`focusin`/`focusout` events to toggle visibility by adding/removing `body.sidenotes-open`.
- Provide a settings tab to configure the note path, panel width, edge activation distance, and peek width, and persist those settings with `loadData`/`saveData` and CSS variables.
- Add `styles.css` for the fixed, slide-out panel, peek behavior, transitions, and basic view styling, and include `README.md` with setup and usage instructions.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696deecf43548326af715ac35c53a884)